### PR TITLE
Support enabling/disabling mouse/keyboard movement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.1.3"
+bevy = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! There's also a basic piece of example code included in `/examples/basic.rs`
 use bevy::{
-	input::mouse::{MouseButton, MouseButtonInput, MouseMotion},
+	input::mouse::{MouseButton, MouseMotion},
 	prelude::*,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub struct FlyCamera {
 	pub key_up: KeyCode,
 	/// Key used to move forward. Defaults to `LShift`
 	pub key_down: KeyCode,
-	/// Whether activate movement is a toggle or has to be held down. Defaults to `false`
+	/// Whether activate movement is a toggle or has to be held down. Defaults to `true`
 	pub activate_is_toggle: bool,
 	/// Mouse button used to activate movement. Defaults to `None`
 	pub mouse_button_activate: Option<MouseButton>,
@@ -92,7 +92,7 @@ impl Default for FlyCamera {
 			key_right: KeyCode::D,
 			key_up: KeyCode::Space,
 			key_down: KeyCode::LShift,
-			activate_is_toggle: false,
+			activate_is_toggle: true,
 			mouse_button_activate: None,
 			key_activate: None,
 		}
@@ -211,10 +211,18 @@ fn camera_movement_system(
 	}
 }
 
-#[derive(Default)]
 struct State {
 	mouse_motion_event_reader: EventReader<MouseMotion>,
 	activated: bool,
+}
+
+impl Default for State {
+	fn default() -> Self {
+		State {
+			mouse_motion_event_reader: EventReader::default(),
+			activated: true,
+		}
+	}
 }
 
 fn mouse_motion_system(


### PR DESCRIPTION
I wanted to be able to enable/disable the FlyCamera movement systems so that I could use this crate for controlling the camera, and still be able to interact with UI elements.

I intend to use this with `mouse_button_activate = Some(MouseButton::Right)` and `activate_is_toggle = false` to work similarly to some other game engines I've used but I thought I'd make it a bit more flexible while I was at it. 😄 

I've made it so that you can specify a mouse button or key to 'activate' motion, and then if `activate_is_toggle` is set, then pressing the button/key will toggle whether movement is activated, else if it is not set, you have to hold down the button/key for movement to be activated.

I also made the default be `activate_is_toggle = true` and no 'bindings' set, and the 'activate' state is `true` so that the default behaviour before this PR is preserved where movement is always on.

**NOTE:** This is based on PR #2 .