### PR TITLE
RFC: Camera system responds to (and emits by default) CameraEvents, instead of user input directly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,8 @@ pub mod camera_events {
 
 	#[derive(Debug)]
 	pub enum EventType {
+		// Move forward or back, bool is whether to move horizontally
+		// FIXME: should non-horizontal movement be a separate enum? (MoveLook?)
 		Move(f32, bool),
 		Strafe(f32),
 		MoveVertical(f32),


### PR DESCRIPTION
This abstracts out keyboard handling into separate event emitting functions, to make it easier to have more advanced keybindings (i.e. keyboard modifiers), and to allow coexistence with other camera systems (i.e. an orbital camera) without reinventing the wheel.

This is very fresh, and requires changes to plugin registration, or documentation on how to rig up event emitting code.

Thoughts welcome!