### PR TITLE
Update Bevy to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_fly_camera"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["mcpar-land"]
 edition = "2021"
 exclude = [".vscode/**"]
@@ -12,4 +12,4 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.10.0" }
+bevy = { version = "0.11.0" }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ use bevy_fly_camera::{FlyCamera, FlyCameraPlugin};
 fn setup(commands: &mut Commands) {
   commands
     .spawn(Camera3dBundle::default())
-    .with(FlyCamera::default());
+    .insert(FlyCamera::default());
 }
 
 fn main() {
@@ -46,7 +46,7 @@ use bevy_fly_camera::{FlyCamera2d, FlyCameraPlugin};
 fn setup(commands: &mut Commands) {
   commands
     .spawn(Camera2dBundle::default())
-    .with(FlyCamera2d::default());
+    .insert(FlyCamera2d::default());
 }
 
 fn main() {

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ fn setup(commands: &mut Commands) {
 fn main() {
   App::new()
     .add_plugins(DefaultPlugins)
-    .add_startup_system(setup)
-    .add_plugin(FlyCameraPlugin)
+    .add_systems(Startup, setup)
+    .add_plugins(FlyCameraPlugin)
     .run();
 }
 ```
@@ -52,8 +52,8 @@ fn setup(commands: &mut Commands) {
 fn main() {
   App::new()
     .add_plugins(DefaultPlugins)
-    .add_startup_system(setup)
-    .add_plugin(FlyCameraPlugin)
+    .add_systems(Startup, setup)
+    .add_plugins(FlyCameraPlugin)
     .run();
 }
 ```
@@ -84,3 +84,4 @@ Any PRs are also welcome, though keep in mind that the project scope is intentio
 | `0.6.0`      | `0.8.0`                   |
 | `0.9.0`      | `0.9.0`                   |
 | `0.10.0`     | `0.10.0`                  |
+| `0.11.0`     | `0.11.0`                  |

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -4,7 +4,6 @@ use bevy_fly_camera::{FlyCamera2d, FlyCameraPlugin};
 fn init(
 	mut commands: Commands,
 	asset_server: Res<AssetServer>,
-	mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
 	commands
 		.spawn(Camera2dBundle::default())
@@ -31,7 +30,7 @@ fn main() {
 	App::new()
 		.insert_resource(Msaa::Sample4)
 		.add_plugins(DefaultPlugins)
-		.add_startup_system(init)
-		.add_plugin(FlyCameraPlugin)
+		.add_systems(Startup, init)
+		.add_plugins(FlyCameraPlugin)
 		.run();
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -57,8 +57,8 @@ fn main() {
 	App::new()
 		.insert_resource(Msaa::Sample4)
 		.add_plugins(DefaultPlugins)
-		.add_startup_system(init)
-		.add_plugin(FlyCameraPlugin)
-		.add_system(toggle_button_system)
+		.add_systems(Startup, init)
+		.add_plugins(FlyCameraPlugin)
+		.add_systems(Update, toggle_button_system)
 		.run();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@
 //! fn main() {
 //!	  App::build()
 //!     .add_plugins(DefaultPlugins)
-//!     .add_startup_system(setup.system())
-//!     .add_plugin(FlyCameraPlugin)
+//!     .add_systems(Startup, setup)
+//!     .add_plugins(FlyCameraPlugin)
 //!     .run();
 //! }
 //! ```
@@ -115,7 +115,7 @@ impl Default for FlyCamera {
 			key_left: KeyCode::A,
 			key_right: KeyCode::D,
 			key_up: KeyCode::Space,
-			key_down: KeyCode::LShift,
+			key_down: KeyCode::ShiftLeft,
 			enabled: true,
 		}
 	}
@@ -231,7 +231,7 @@ Include this plugin to add the systems for the FlyCamera bundle.
 
 ```no_compile
 fn main() {
-	App::build().add_plugin(FlyCameraPlugin);
+	App::build().add_plugins(FlyCameraPlugin);
 }
 ```
 
@@ -242,8 +242,8 @@ pub struct FlyCameraPlugin;
 impl Plugin for FlyCameraPlugin {
 	fn build(&self, app: &mut App) {
 		app
-			.add_system(camera_movement_system)
-			.add_system(camera_2d_movement_system)
-			.add_system(mouse_motion_system);
+			.add_systems(Update, camera_movement_system)
+			.add_systems(Update, camera_2d_movement_system)
+			.add_systems(Update, mouse_motion_system);
 	}
 }


### PR DESCRIPTION
Primary changes are switching to using `.add_systems(..., ...)` and `.add_plugins(...)`.  Also corrected `KeyCode::ShiftLeft` and removed unused `materials` arg in the 2d example.